### PR TITLE
Fix for null values causing a DOM error

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,9 @@ module.exports = {
                                  div.style.marginLeft = "30px";
                                  colon = document.createTextNode(':  ');
                                  div.appendChild(strong).appendChild(colon);
-                                 div.appendChild(prettyPrint(json[keys[i]], div));
+                                 var json_keys_i = json[keys[i]];
+                                 if(!json_keys_i) json_keys_i = '(empty)'
+                                 div.appendChild(prettyPrint(json_keys_i, div));
                                  if((len - i) !== 1) {
                                    div.appendChild(document.createTextNode(','));
                                  }


### PR DESCRIPTION
Simple fix for the following error happening when one of the attibutes values were `null`:

`Uncaught HierarchyRequestError: Failed to execute 'appendChild' on 'Node': The new child element contains the parent.
`

Now the `null` is being replaced by `(empty)` which is more readable by humans but not accurate, so maybe you want to change that.
